### PR TITLE
envsetup: Disable ABI checking by default

### DIFF
--- a/build/envsetup.sh
+++ b/build/envsetup.sh
@@ -53,3 +53,6 @@ function repopick() {
     T=$(gettop)
     $T/vendor/ssos/build/tools/repopick.py $@
 }
+
+# Disable ABI checking
+export SKIP_ABI_CHECKS=true


### PR DESCRIPTION
 * this is useless to us and fails after https://github.com/Wave-Project/frameworks_native/commit/245b9c8c75abd83b10b820a81653fde26fe743e8
 * so let's yeet off abi checking and also reduce build time a bit :)